### PR TITLE
Clustering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ async function createIssueOnAllRepos (org) {
 
 Pass `{ throttle: { enabled: false } }` to disable this plugin.
 
-### Redis
+### Clustering
 
-Enabling Redis support ensures that your application will not go over rate limits **across Octokit instances and across Nodejs processes**.
+Enabling Clustering support ensures that your application will not go over rate limits **across Octokit instances and across Nodejs processes**.
 
 First install either `redis` or `ioredis`:
 ```
@@ -82,15 +82,19 @@ const octokit = new Octokit({
     onAbuseLimit: (retryAfter, options) => { /* ... */ },
     onRateLimit: (retryAfter, options) => { /* ... */ },
 
-    // Pass the Bottleneck connection object
+    // The Bottleneck connection object
     connection,
+
+    // A "throttling ID". All octokit instances with the same ID
+    // using the same Redis server will share the throttling.
+    id: 'my-super-app',
 
     // Otherwise the plugin uses a lighter version of Bottleneck without Redis support
     Bottleneck
   }
 })
 
-// Clean disconnection
+// To close the connection and allow your application to exit cleanly:
 await connection.disconnect()
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 module.exports = throttlingPlugin
 
-const Bottleneck = require('bottleneck/light')
+const BottleneckLight = require('bottleneck/light')
 const wrapRequest = require('./wrap-request')
 const triggersNotificationPaths = require('./triggers-notification-paths')
 const routeMatcher = require('./route-matcher')(triggersNotificationPaths)
@@ -10,21 +10,34 @@ const triggersNotification = throttlingPlugin.triggersNotification =
   routeMatcher.test.bind(routeMatcher)
 
 function throttlingPlugin (octokit, octokitOptions = {}) {
+  const { Bottleneck = BottleneckLight, connection } = octokitOptions.throttle || {}
+  const common = {
+    connection,
+    timeout: 1000 * 60 * 10 // Redis TTL: 10 minutes
+  }
+
   const state = Object.assign({
     enabled: true,
+    clustering: connection != null,
     triggersNotification,
     minimumAbuseRetryAfter: 5,
     retryAfterBaseValue: 1000,
     globalLimiter: new Bottleneck({
-      maxConcurrent: 1
+      id: 'octokit-global',
+      maxConcurrent: 1,
+      ...common
     }),
     writeLimiter: new Bottleneck({
+      id: 'octokit-write',
       maxConcurrent: 1,
-      minTime: 1000
+      minTime: 1000,
+      ...common
     }),
     triggersNotificationLimiter: new Bottleneck({
+      id: 'octokit-notifications',
       maxConcurrent: 1,
-      minTime: 3000
+      minTime: 3000,
+      ...common
     }),
     retryLimiter: new Bottleneck()
   }, octokitOptions.throttle)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,12 @@ const triggersNotification = throttlingPlugin.triggersNotification =
   routeMatcher.test.bind(routeMatcher)
 
 function throttlingPlugin (octokit, octokitOptions = {}) {
-  const { enabled = true, Bottleneck = BottleneckLight, connection } = octokitOptions.throttle || {}
+  const {
+    enabled = true,
+    Bottleneck = BottleneckLight,
+    id = 'no-id',
+    connection
+  } = octokitOptions.throttle || {}
   if (!enabled) {
     return
   }
@@ -24,18 +29,18 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
     minimumAbuseRetryAfter: 5,
     retryAfterBaseValue: 1000,
     globalLimiter: new Bottleneck({
-      id: 'octokit-global',
+      id: `octokit-global-${id}`,
       maxConcurrent: 1,
       ...common
     }),
     writeLimiter: new Bottleneck({
-      id: 'octokit-write',
+      id: `octokit-write-${id}`,
       maxConcurrent: 1,
       minTime: 1000,
       ...common
     }),
     triggersNotificationLimiter: new Bottleneck({
-      id: 'octokit-notifications',
+      id: `octokit-notifications-${id}`,
       maxConcurrent: 1,
       minTime: 3000,
       ...common

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,14 +10,15 @@ const triggersNotification = throttlingPlugin.triggersNotification =
   routeMatcher.test.bind(routeMatcher)
 
 function throttlingPlugin (octokit, octokitOptions = {}) {
-  const { Bottleneck = BottleneckLight, connection } = octokitOptions.throttle || {}
+  const { enabled = true, Bottleneck = BottleneckLight, connection } = octokitOptions.throttle || {}
+  if (!enabled) {
+    return
+  }
   const common = {
     connection,
     timeout: 1000 * 60 * 10 // Redis TTL: 10 minutes
   }
-
   const state = Object.assign({
-    enabled: true,
     clustering: connection != null,
     triggersNotification,
     minimumAbuseRetryAfter: 5,
@@ -41,10 +42,6 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
     }),
     retryLimiter: new Bottleneck()
   }, octokitOptions.throttle)
-
-  if (!state.enabled) {
-    return
-  }
 
   if (typeof state.onAbuseLimit !== 'function' || typeof state.onRateLimit !== 'function') {
     throw new Error(`octokit/plugin-throttling error:

--- a/lib/wrap-request.js
+++ b/lib/wrap-request.js
@@ -10,6 +10,11 @@ async function doRequest (state, request, options) {
   const isWrite = options.method !== 'GET' && options.method !== 'HEAD'
   const retryCount = ~~options.request.retryCount
   const jobOptions = retryCount > 0 ? { priority: 0, weight: 0 } : {}
+  if (state.clustering) {
+    // Remove a job from Redis if it has not completed or failed within 60s
+    // Examples: Node process terminated, client disconnected, etc.
+    jobOptions.expiration = 1000 * 60
+  }
 
   // Guarantee at least 1000ms between writes
   if (isWrite) {


### PR DESCRIPTION
I tested it manually because adding an automated test for it means adding a dev dependency on either `redis` or `ioredis`.

### Usage
```js
const Bottleneck = require('bottleneck')
const Redis = require('redis')

const client = Redis.createClient({ /* options */ })
const connection = new Bottleneck.RedisConnection({ client })
connection.on('error', err => console.error(err))

const octokit = new Octokit({
  throttle: {
    onAbuseLimit: (...args) => console.log(...args),
    onRateLimit: (...args) => console.log(...args),
    Bottleneck, // full, not the light bundle
    connection
  }
})

await connection.disconnect()
```

It also supports the `ioredis` library:
```js
const Redis = require('ioredis')
const client = new Redis({ /* options */ })
const connection = new Bottleneck.IORedisConnection({ client })
connection.on('error', err => console.error(err))
```