### PR TITLE
feat: proof of concept for reused limiters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,3 @@
-console.log('TEST TEST TEST')
-
 module.exports = throttlingPlugin
 
 const BottleneckLight = require('bottleneck/light')
@@ -38,17 +36,15 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
     enabled = true,
     Bottleneck = BottleneckLight,
     id = 'no-id',
+    timeout = 1000 * 60 * 2, // Redis TTL: 2 minutes
     connection
   } = octokitOptions.throttle || {}
   if (!enabled) {
     return
   }
-  const common = {
-    connection,
-    timeout: 1000 * 60 * 2 // Redis TTL: 2 minutes
-  }
+  const common = { connection, timeout }
 
-  if (groups.globalLimiter == null) {
+  if (groups.global == null) {
     createGroups(Bottleneck, common)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,28 @@ const routeMatcher = require('./route-matcher')(triggersNotificationPaths)
 const triggersNotification = throttlingPlugin.triggersNotification =
   routeMatcher.test.bind(routeMatcher)
 
+const groups = {}
+
+const createGroups = function (Bottleneck, common) {
+  groups.global = new Bottleneck.Group({
+    id: 'octokit-global',
+    maxConcurrent: 1,
+    ...common
+  })
+  groups.write = new Bottleneck.Group({
+    id: 'octokit-write',
+    maxConcurrent: 1,
+    minTime: 1000,
+    ...common
+  })
+  groups.notifications = new Bottleneck.Group({
+    id: 'octokit-notifications',
+    maxConcurrent: 1,
+    minTime: 3000,
+    ...common
+  })
+}
+
 function throttlingPlugin (octokit, octokitOptions = {}) {
   const {
     enabled = true,
@@ -23,29 +45,19 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
     connection,
     timeout: 1000 * 60 * 10 // Redis TTL: 10 minutes
   }
+
+  if (groups.globalLimiter == null) {
+    createGroups(Bottleneck, common)
+  }
+
   const state = Object.assign({
     clustering: connection != null,
     triggersNotification,
     minimumAbuseRetryAfter: 5,
     retryAfterBaseValue: 1000,
-    globalLimiter: new Bottleneck({
-      id: `octokit-global-${id}`,
-      maxConcurrent: 1,
-      ...common
-    }),
-    writeLimiter: new Bottleneck({
-      id: `octokit-write-${id}`,
-      maxConcurrent: 1,
-      minTime: 1000,
-      ...common
-    }),
-    triggersNotificationLimiter: new Bottleneck({
-      id: `octokit-notifications-${id}`,
-      maxConcurrent: 1,
-      minTime: 3000,
-      ...common
-    }),
-    retryLimiter: new Bottleneck()
+    retryLimiter: new Bottleneck(),
+    id,
+    ...groups
   }, octokitOptions.throttle)
 
   if (typeof state.onAbuseLimit !== 'function' || typeof state.onRateLimit !== 'function') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function throttlingPlugin (octokit, octokitOptions = {}) {
   }
   const common = {
     connection,
-    timeout: 1000 * 60 * 10 // Redis TTL: 10 minutes
+    timeout: 1000 * 60 * 2 // Redis TTL: 2 minutes
   }
 
   if (groups.globalLimiter == null) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+console.log('TEST TEST TEST')
+
 module.exports = throttlingPlugin
 
 const BottleneckLight = require('bottleneck/light')

--- a/lib/wrap-request.js
+++ b/lib/wrap-request.js
@@ -18,13 +18,13 @@ async function doRequest (state, request, options) {
 
   // Guarantee at least 1000ms between writes
   if (isWrite) {
-    await state.writeLimiter.schedule(jobOptions, noop)
+    await state.write.key(state.id).schedule(jobOptions, noop)
   }
 
   // Guarantee at least 3000ms between requests that trigger notifications
   if (isWrite && state.triggersNotification(options.url)) {
-    await state.triggersNotificationLimiter.schedule(jobOptions, noop)
+    await state.notifications.key(state.id).schedule(jobOptions, noop)
   }
 
-  return state.globalLimiter.schedule(jobOptions, request, options)
+  return state.global.key(state.id).schedule(jobOptions, request, options)
 }

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -83,7 +83,7 @@ describe('Github API best practices', function () {
   it('Should maintain 1000ms between mutating requests', async function () {
     const octokit = new Octokit({
       throttle: {
-        writeLimiter: new Bottleneck({ minTime: 50 }),
+        write: new Bottleneck.Group({ minTime: 50 }),
         onAbuseLimit: () => 1,
         onRateLimit: () => 1
       }
@@ -120,8 +120,8 @@ describe('Github API best practices', function () {
   it('Should maintain 3000ms between requests that trigger notifications', async function () {
     const octokit = new Octokit({
       throttle: {
-        writeLimiter: new Bottleneck({ minTime: 50 }),
-        triggersNotificationLimiter: new Bottleneck({ minTime: 100 }),
+        write: new Bottleneck.Group({ minTime: 50 }),
+        notifications: new Bottleneck.Group({ minTime: 100 }),
         onAbuseLimit: () => 1,
         onRateLimit: () => 1
       }
@@ -175,8 +175,8 @@ describe('Github API best practices', function () {
   it('Should optimize throughput rather than maintain ordering', async function () {
     const octokit = new Octokit({
       throttle: {
-        writeLimiter: new Bottleneck({ minTime: 50 }),
-        triggersNotificationLimiter: new Bottleneck({ minTime: 100 }),
+        write: new Bottleneck.Group({ minTime: 50 }),
+        notifications: new Bottleneck.Group({ minTime: 100 }),
         onAbuseLimit: () => 1,
         onRateLimit: () => 1
       }


### PR DESCRIPTION
~Not ready for merging.~

What this does is reuse limiters across plugin instantiations as long as their `id` option matches.

`Bottleneck.Group` is a cache for limiter instances, they're automatically deleted after `timeout` ms of inactivity (set to 2 minutes).

Important note: Right now, if the first instance of the plugin uses Redis, then all other instances will use it too even if they don't pass `connection`. And if the first `.plugin()` didn't use redis, then the other `.plugin()` will also not use it.