### PR TITLE
feat: Throttle search routes, allow parallel GET/HEAD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,13 @@ const groups = {}
 const createGroups = function (Bottleneck, common) {
   groups.global = new Bottleneck.Group({
     id: 'octokit-global',
+    maxConcurrent: 10,
+    ...common
+  })
+  groups.search = new Bottleneck.Group({
+    id: 'octokit-search',
     maxConcurrent: 1,
+    minTime: 2000,
     ...common
   })
   groups.write = new Bottleneck.Group({

--- a/lib/wrap-request.js
+++ b/lib/wrap-request.js
@@ -8,6 +8,8 @@ function wrapRequest (state, request, options) {
 
 async function doRequest (state, request, options) {
   const isWrite = options.method !== 'GET' && options.method !== 'HEAD'
+  const isSearch = options.method === 'GET' && options.url.startsWith('/search/')
+
   const retryCount = ~~options.request.retryCount
   const jobOptions = retryCount > 0 ? { priority: 0, weight: 0 } : {}
   if (state.clustering) {
@@ -24,6 +26,10 @@ async function doRequest (state, request, options) {
   // Guarantee at least 3000ms between requests that trigger notifications
   if (isWrite && state.triggersNotification(options.url)) {
     await state.notifications.key(state.id).schedule(jobOptions, noop)
+  }
+
+  if (isSearch) {
+    await state.search.key(state.id).schedule(jobOptions, noop)
   }
 
   return state.global.key(state.id).schedule(jobOptions, request, options)


### PR DESCRIPTION
Fixes #44 

- Allows up to 10 GET/HEAD requests in parallel.
- Throttles the Search API separately.