### PR TITLE
Handle 403 errors with non-zero rate-limit remaining

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,13 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
     const options = info.args[info.args.length - 1];
     const isGraphQL = options.url.startsWith("/graphql");
 
-    if (!(isGraphQL || error.status === 403 || (typeof state.onTimeout === "function" && error.status === 500))) {
+    if (
+      !(
+        isGraphQL ||
+        error.status === 403 ||
+        (typeof state.onTimeout === "function" && error.status === 500)
+      )
+    ) {
       return;
     }
 
@@ -181,8 +187,6 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
       }
       return {};
     })();
-
- 
 
     if (wantRetry) {
       options.request.retryCount++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
     const options = info.args[info.args.length - 1];
     const isGraphQL = options.url.startsWith("/graphql");
 
-    if (!(isGraphQL || error.status === 403)) {
+    if (!(isGraphQL || error.status === 403 || (typeof state.onTimeout === "function" && error.status === 500))) {
       return;
     }
 
@@ -168,7 +168,7 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
           Math.ceil((rateLimitReset - Date.now()) / 1000),
           0
         );
-        if (error.headers["x-ratelimit-remaining"] !== 0) {
+        if (error.headers["x-ratelimit-remaining"] !== "0") {
           retryAfter = 60; // The ratelimit has been reset but still getting a 403, try a short wait and let the handler decide what to do
         }
         const wantRetry = await emitter.trigger(
@@ -181,6 +181,8 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
       }
       return {};
     })();
+
+ 
 
     if (wantRetry) {
       options.request.retryCount++;


### PR DESCRIPTION
Changes the 403 handling so that it will retry even if the rate-limit remaining is non zero (could this be a bug in the github api?).
Additionally adds an optionally handler for 500 timeouts.  
Adds tests but I am still a bit short on test coverage and a bit lost on how to test the remaining uncovered lines.