### PR TITLE
fix: do not retry GraphQl request in case for 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![@latest](https://img.shields.io/npm/v/@octokit/plugin-throttling.svg)](https://www.npmjs.com/package/@octokit/plugin-throttling)
 [![Build Status](https://github.com/octokit/plugin-throttling.js/workflows/Test/badge.svg)](https://github.com/octokit/plugin-throttling.js/actions?workflow=Test)
 
-Implements all [recommended best practises](https://developer.github.com/v3/guides/best-practices-for-integrators/) to prevent hitting abuse rate limits.
+Implements all [recommended best practises](https://docs.github.com/en/rest/guides/best-practices-for-integrators) to prevent hitting abuse rate limits.
 
 ## Usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,10 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
   // @ts-ignore
   state.retryLimiter.on("failed", async function (error, info) {
     const options = info.args[info.args.length - 1];
-    const isGraphQL = options.url.startsWith("/graphql");
+    const shouldRetryGraphQL =
+      options.url.startsWith("/graphql") && error.status !== 401;
 
-    if (!(isGraphQL || error.status === 403)) {
+    if (!(shouldRetryGraphQL || error.status === 403)) {
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,8 +120,8 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
 
     const { wantRetry, retryAfter } = await (async function () {
       if (/\babuse\b/i.test(error.message)) {
-        // The user has hit the abuse rate limit. (REST only)
-        // https://developer.github.com/v3/#abuse-rate-limits
+        // The user has hit the abuse rate limit. (REST and GraphQL)
+        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits
 
         // The Retry-After header can sometimes be blank when hitting an abuse limit,
         // but is always present after 2-3s, so make sure to set `retryAfter` to at least 5s by default.
@@ -142,7 +142,8 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
         error.headers["x-ratelimit-remaining"] === "0"
       ) {
         // The user has used all their allowed calls for the current time period (REST and GraphQL)
-        // https://developer.github.com/v3/#rate-limiting
+        // https://docs.github.com/en/rest/reference/rate-limit (REST)
+        // https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit (GraphQL)
 
         const rateLimitReset = new Date(
           ~~error.headers["x-ratelimit-reset"] * 1000


### PR DESCRIPTION
This updates the bottleneck "failed" handler to not retry GraphQL
requests that receive a 401 response. The old behavior was to retry all
GraphQL error responses, which caused the retry to be throttled for an
hour, due to 401 Unauthorized responses including an
`x-ratelimit-remaining` of `0` and a `x-ratelimit-reset` of now + 3600
seconds. The main issue was that the request wasn't being ratelimited,
but the ratelimit headers caused the plugin to wait.

In testing this out, I noticed that GraphQL responses can also receive a
403 Forbidden response when hitting the abuse rate limit. This commit
keeps the functionality for retrying 403 responses for GraphQL requests,
since they signify abuse rate limiting, where 401 responses indicate bad
credentials.

Fixes #229 