### PR TITLE
Add throttleGraphQL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ const MyOctokit = Octokit.plugin(throttling);
 const octokit = new MyOctokit({
   auth: `secret123`,
   throttle: {
+    throttleGraphQL: false, // (defaults to true) whether or not to throttle GraphQL requests
     onRateLimit: (retryAfter, options, octokit) => {
       octokit.log.warn(
         `Request quota exhausted for request ${options.method} ${options.url}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
       retryAfterBaseValue: 1000,
       retryLimiter: new Bottleneck(),
       id,
+      throttleGraphQL: true,
       ...groups,
     },
     // @ts-ignore


### PR DESCRIPTION
I recently ran into a (potentially rare) scenario where I was making requests to both REST endpoints & GraphQL endpoints and I needed my REST requests to be throttled, but did not want my GraphQL requests to be throttled since they were all read requests.

This PR introduces a new boolean option, `throttleGraphQL`, which allows users to select whether or not they want to throttle GraphQL requests when using this plugin.