### PR TITLE
fix(typescript): return `{}` instead of `void`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
     // @ts-ignore
   } = octokitOptions.throttle || {};
   if (!enabled) {
-    return;
+    return {};
   }
   const common = { connection, timeout };
 
@@ -172,6 +172,8 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
   });
 
   octokit.hook.wrap("request", wrapRequest.bind(null, state));
+
+  return {};
 }
 throttling.VERSION = VERSION;
 throttling.triggersNotification = triggersNotification;


### PR DESCRIPTION
addresses part of https://github.com/octokit/octokit.js/issues/2115
