### PR TITLE
fix: adapt to GitHub's rename of abuse limit to secondary rate limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export function throttling(octokit: Octokit, octokitOptions = {}) {
     options.request.retryCount = retryCount;
 
     const { wantRetry, retryAfter } = await (async function () {
-      if (/\babuse\b/i.test(error.message)) {
+      if (/\bsecondary rate\b/i.test(error.message)) {
         // The user has hit the abuse rate limit. (REST and GraphQL)
         // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -68,7 +68,7 @@ describe("Events", function () {
                 status: 403,
                 headers: { "retry-after": "60" },
                 data: {
-                  message: "You have been rate limited to prevent abuse",
+                  message: "You have exceeded a secondary rate limit",
                 },
               },
             ],
@@ -112,7 +112,7 @@ describe("Events", function () {
                 status: 403,
                 headers: { "retry-after": "2" },
                 data: {
-                  message: "You have been rate limited to prevent abuse",
+                  message: "You have exceeded a secondary rate limit",
                 },
               },
             ],
@@ -156,7 +156,7 @@ describe("Events", function () {
                 status: 403,
                 headers: {},
                 data: {
-                  message: "You have been rate limited to prevent abuse",
+                  message: "You have exceeded a secondary rate limit",
                 },
               },
             ],

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -29,7 +29,7 @@ describe("Retry", function () {
             {
               status: 403,
               headers: { "retry-after": "1" },
-              data: { message: "You have been rate limited to prevent abuse" },
+              data: { message: "You have exceeded a secondary rate limit" },
             },
             { status: 200, headers: {}, data: { message: "Success!" } },
           ],
@@ -69,7 +69,7 @@ describe("Retry", function () {
         },
       });
 
-      const message = "You have been rate limited to prevent abuse";
+      const message = "You have exceeded a secondary rate limit";
       try {
         await octokit.request("GET /route", {
           request: {
@@ -366,7 +366,7 @@ describe("Retry", function () {
               },
               data: {
                 message:
-                  "You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.",
+                  "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
                 documentation_url:
                   "https://developer.github.com/v3/#abuse-rate-limits",
               },


### PR DESCRIPTION
close #437