### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
         "@pika/plugin-build-node",
         {
           "minNodeVersion": "14"
+        },
+        {
+          "minNodeVersion": "14"
         }
       ],
       [


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12