### PR TITLE
fix(retry-count): don't leak retryCount between requests: updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ const MyOctokit = Octokit.plugin(throttling);
 const octokit = new MyOctokit({
   auth: `secret123`,
   throttle: {
-    onRateLimit: (retryAfter, options, octokit) => {
+    onRateLimit: (retryAfter, options, octokit, retryCount) => {
       octokit.log.warn(
         `Request quota exhausted for request ${options.method} ${options.url}`
       );
 
-      if (options.request.retryCount === 0) {
+      if (retryCount < 1) {
         // only retries once
         octokit.log.info(`Retrying after ${retryAfter} seconds!`);
         return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,10 @@ declare module "@octokit/core/dist-types/types.d" {
 }
 
 type LimitHandler = (
-  retryAfter?: number,
-  options?: object,
-  octokit?: Octokit
+  retryAfter: number,
+  options: object,
+  octokit: Octokit,
+  retryCount: number
 ) => void;
 
 export type AbuseLimitHandler = {

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -12,7 +12,7 @@ async function doRequest(state, request, options) {
   const isSearch = options.method === "GET" && pathname.startsWith("/search/");
   const isGraphQL = pathname.startsWith("/graphql");
 
-  const retryCount = ~~options.request.retryCount;
+  const retryCount = ~~request.retryCount;
   const jobOptions = retryCount > 0 ? { priority: 0, weight: 0 } : {};
   if (state.clustering) {
     // Remove a job from Redis if it has not completed or failed within 60s

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -124,17 +124,21 @@ describe("Retry", function () {
       const server = createServer((req, res) => {
         if (counter++ % 3 === 0) {
           res
-            .writeHead(200, {"Content-Type": "application/json"})
+            .writeHead(200, { "Content-Type": "application/json" })
             .end(JSON.stringify({ message: "Success!" }));
         } else {
           res
             .writeHead(403, {
               "Content-Type": "application/json",
-              "retry-after": "1"
+              "retry-after": "1",
             })
-            .end(JSON.stringify({ message: "You have exceeded a secondary rate limit" }));
+            .end(
+              JSON.stringify({
+                message: "You have exceeded a secondary rate limit",
+              })
+            );
         }
-      })
+      });
 
       server.listen(0);
       const { port } = server.address() as AddressInfo;


### PR DESCRIPTION
This is an updated version of #462. 
As asked, replaced `express` in tests with native http module, and fixed the conflicts.

Closes #462
Fixes #442