### PR TITLE
Fix docs link in src/index.ts:86

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
   ) {
     throw new Error(`octokit/plugin-throttling error:
         You must pass the onSecondaryRateLimit and onRateLimit error handlers.
-        See https://octokit.github.io/rest.js/v19#throttling
+        See https://octokit.github.io/rest.js/#throttling
 
         const octokit = new Octokit({
           throttle: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
   ) {
     throw new Error(`octokit/plugin-throttling error:
         You must pass the onSecondaryRateLimit and onRateLimit error handlers.
-        See https://github.com/octokit/rest.js#throttling
+        See https://octokit.github.io/rest.js/v19#throttling
 
         const octokit = new Octokit({
           throttle: {


### PR DESCRIPTION
Fixes #555. 

The docs URL for octokit/rest.js has changed since implementation here. 