### PR TITLE
fix(types): move `OctokitOptions` augmentation to the index file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import BottleneckLight from "bottleneck/light";
 import { Octokit } from "@octokit/core";
 import { OctokitOptions } from "@octokit/core/dist-types/types.d";
-import { Groups } from "./types";
+import { Groups, ThrottlingOptions } from "./types";
 import { VERSION } from "./version";
 
 import { wrapRequest } from "./wrap-request";
@@ -192,3 +192,9 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
 }
 throttling.VERSION = VERSION;
 throttling.triggersNotification = triggersNotification;
+
+declare module "@octokit/core/dist-types/types.d" {
+  interface OctokitOptions {
+    throttle?: ThrottlingOptions;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,6 @@
 import { Octokit } from "@octokit/core";
 import Bottleneck from "bottleneck";
 
-declare module "@octokit/core/dist-types/types.d" {
-  interface OctokitOptions {
-    throttle?: ThrottlingOptions;
-  }
-}
-
 type LimitHandler = (
   retryAfter: number,
   options: object,


### PR DESCRIPTION
1. currently `import { throttling } from "@octokit/plugin-throttling";` doesn't lead to loading `@octokit/plugin-throttling/dist-types/types.d.ts` as that's not referenced by the index file anyhow
2. so TS doesn't load that file that contains the `OctokitOptions` augmentation and thus it doesn't see the types for the `OctokitOptions['throttle']` without putting `import "@octokit/plugin-throttling/dist-types/types.d";` at the top of the consuming file