### PR TITLE
fix: bump minimal retry in case of secondary rate limiting to 60s

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,10 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     octokit.log.warn(
       "[@octokit/plugin-throttling] `onAbuseLimit()` is deprecated and will be removed in a future release of `@octokit/plugin-throttling`, please use the `onSecondaryRateLimit` handler instead"
     );
-    // @ts-expect-error types don't allow for both properties to be set
+    // @ts-ignore types don't allow for both properties to be set
     octokitOptions.throttle.onSecondaryRateLimit =
       octokitOptions.throttle.onAbuseLimit;
-    // @ts-expect-error
+    // @ts-ignore
     delete octokitOptions.throttle.onAbuseLimit;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
         // The Retry-After header can sometimes be blank when hitting a secondary rate limit,
         // but is always present after 2-3s, so make sure to set `retryAfter` to at least 5s by default.
         const retryAfter =
-          error.response.headers["retry-after"] ||
+          Number(error.response.headers["retry-after"]) ||
           state.fallbackSecondaryRateRetryAfter;
         const wantRetry = await emitter.trigger(
           "secondary-limit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
         // but is always present after 2-3s, so make sure to set `retryAfter` to at least 5s by default.
         const retryAfter =
           error.response.headers["retry-after"] ||
-          state.minimumSecondaryRateRetryAfter;
+          state.fallbackSecondaryRateRetryAfter;
         const wantRetry = await emitter.trigger(
           "secondary-limit",
           retryAfter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     {
       clustering: connection != null,
       triggersNotification,
-      minimumSecondaryRateRetryAfter: 5,
+      fallbackSecondaryRateRetryAfter: 60,
       retryAfterBaseValue: 1000,
       retryLimiter: new Bottleneck(),
       id,
@@ -140,10 +140,9 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
 
         // The Retry-After header can sometimes be blank when hitting a secondary rate limit,
         // but is always present after 2-3s, so make sure to set `retryAfter` to at least 5s by default.
-        const retryAfter = Math.max(
-          ~~error.response.headers["retry-after"],
-          state.minimumSecondaryRateRetryAfter
-        );
+        const retryAfter =
+          error.response.headers["retry-after"] ||
+          state.minimumSecondaryRateRetryAfter;
         const wantRetry = await emitter.trigger(
           "secondary-limit",
           retryAfter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,18 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     createGroups(Bottleneck, common);
   }
 
+  if (
+    octokitOptions.throttle &&
+    octokitOptions.throttle.minimalSecondaryRateRetryAfter
+  ) {
+    octokit.log.warn(
+      "[@octokit/plugin-throttling] `options.throttle.minimalSecondaryRateRetryAfter` is deprecated, please use `options.throttle.fallbackSecondaryRateRetryAfter` instead"
+    );
+    octokitOptions.throttle.fallbackSecondaryRateRetryAfter =
+      octokitOptions.throttle.minimalSecondaryRateRetryAfter;
+    delete octokitOptions.throttle.minimalSecondaryRateRetryAfter;
+  }
+
   const state = Object.assign(
     {
       clustering: connection != null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export type ThrottlingOptionsBase = {
   timeout?: number;
   connection?: Bottleneck.RedisConnection | Bottleneck.IORedisConnection;
   /**
-   * @deprecated use `fallbackSecondaryRateRetryAfter` instead.
+   * @deprecated use `fallbackSecondaryRateRetryAfter`
    */
   minimalSecondaryRateRetryAfter?: number;
   fallbackSecondaryRateRetryAfter?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export type ThrottlingOptionsBase = {
   id?: string;
   timeout?: number;
   connection?: Bottleneck.RedisConnection | Bottleneck.IORedisConnection;
-  minimumSecondaryRateRetryAfter?: number;
+  fallbackSecondaryRateRetryAfter?: number;
   retryAfterBaseValue?: number;
   write?: Bottleneck.Group;
   search?: Bottleneck.Group;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export type ThrottlingOptionsBase = {
   id?: string;
   timeout?: number;
   connection?: Bottleneck.RedisConnection | Bottleneck.IORedisConnection;
+  /**
+   * @deprecated use `fallbackSecondaryRateRetryAfter` instead.
+   */
+  minimalSecondaryRateRetryAfter?: number;
   fallbackSecondaryRateRetryAfter?: number;
   retryAfterBaseValue?: number;
   write?: Bottleneck.Group;

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -22,4 +22,25 @@ describe("deprecations", () => {
       "[@octokit/plugin-throttling] `options.throttle.minimalSecondaryRateRetryAfter` is deprecated, please use `options.throttle.fallbackSecondaryRateRetryAfter` instead"
     );
   });
+
+  describe("throttle.onAbuseLimit", function () {
+    it("Should detect SecondaryRate limit and broadcast event", async function () {
+      const log = {
+        warn: jest.fn(),
+      };
+
+      new TestOctokit({
+        // @ts-expect-error
+        log,
+        throttle: {
+          onAbuseLimit: () => 1,
+          onRateLimit: () => 1,
+        },
+      });
+
+      expect(log.warn).toHaveBeenCalledWith(
+        "[@octokit/plugin-throttling] `onAbuseLimit()` is deprecated and will be removed in a future release of `@octokit/plugin-throttling`, please use the `onSecondaryRateLimit` handler instead"
+      );
+    });
+  });
 });

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -1,0 +1,25 @@
+import { Octokit } from "@octokit/core";
+import { throttling } from "../src";
+
+const TestOctokit = Octokit.plugin(throttling);
+
+describe("deprecations", () => {
+  it("throttle.minimalSecondaryRateRetryAfter option", () => {
+    const log = {
+      warn: jest.fn(),
+    };
+    new TestOctokit({
+      // @ts-expect-error
+      log,
+      throttle: {
+        minimalSecondaryRateRetryAfter: 1,
+        onSecondaryRateLimit: () => 1,
+        onRateLimit: () => 1,
+      },
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "[@octokit/plugin-throttling] `options.throttle.minimalSecondaryRateRetryAfter` is deprecated, please use `options.throttle.fallbackSecondaryRateRetryAfter` instead"
+    );
+  });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -236,7 +236,7 @@ describe("Events", function () {
         },
       });
 
-      jest.spyOn(octokit.log, "warn");
+      jest.spyOn(octokit.log, "warn").mockImplementation(() => {});
 
       const t0 = Date.now();
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -80,56 +80,12 @@ describe("Events", function () {
         expect(eventCount).toEqual(1);
       });
 
-      it("Should ensure retryAfter is a minimum of 5s", async function () {
+      it("Should broadcast retryAfter of 60s even when the header is missing", async function () {
         let eventCount = 0;
         const octokit = new TestOctokit({
           throttle: {
             onSecondaryRateLimit: (retryAfter, options) => {
-              expect(retryAfter).toEqual(5);
-              expect(options).toMatchObject({
-                method: "GET",
-                url: "/route2",
-                request: { retryCount: 0 },
-              });
-              eventCount++;
-            },
-            onRateLimit: () => 1,
-          },
-        });
-
-        await octokit.request("GET /route1", {
-          request: {
-            responses: [{ status: 201, headers: {}, data: {} }],
-          },
-        });
-        try {
-          await octokit.request("GET /route2", {
-            request: {
-              responses: [
-                {
-                  status: 403,
-                  headers: { "retry-after": "2" },
-                  data: {
-                    message: "You have exceeded a secondary rate limit",
-                  },
-                },
-              ],
-            },
-          });
-          throw new Error("Should not reach this point");
-        } catch (error: any) {
-          expect(error.status).toEqual(403);
-        }
-
-        expect(eventCount).toEqual(1);
-      });
-
-      it("Should broadcast retryAfter of 5s even when the header is missing", async function () {
-        let eventCount = 0;
-        const octokit = new TestOctokit({
-          throttle: {
-            onSecondaryRateLimit: (retryAfter, options) => {
-              expect(retryAfter).toEqual(5);
+              expect(retryAfter).toEqual(60);
               expect(options).toMatchObject({
                 method: "GET",
                 url: "/route2",
@@ -214,94 +170,6 @@ describe("Events", function () {
 
         expect(eventCount).toEqual(1);
       });
-
-      it("Should ensure retryAfter is a minimum of 5s", async function () {
-        let eventCount = 0;
-        const octokit = new TestOctokit({
-          throttle: {
-            onAbuseLimit: (retryAfter, options) => {
-              expect(retryAfter).toEqual(5);
-              expect(options).toMatchObject({
-                method: "GET",
-                url: "/route2",
-                request: { retryCount: 0 },
-              });
-              eventCount++;
-            },
-            onRateLimit: () => 1,
-          },
-        });
-
-        await octokit.request("GET /route1", {
-          request: {
-            responses: [{ status: 201, headers: {}, data: {} }],
-          },
-        });
-        try {
-          await octokit.request("GET /route2", {
-            request: {
-              responses: [
-                {
-                  status: 403,
-                  headers: { "retry-after": "2" },
-                  data: {
-                    message: "You have exceeded a secondary rate limit",
-                  },
-                },
-              ],
-            },
-          });
-          throw new Error("Should not reach this point");
-        } catch (error: any) {
-          expect(error.status).toEqual(403);
-        }
-
-        expect(eventCount).toEqual(1);
-      });
-
-      it("Should broadcast retryAfter of 5s even when the header is missing", async function () {
-        let eventCount = 0;
-        const octokit = new TestOctokit({
-          throttle: {
-            onAbuseLimit: (retryAfter, options) => {
-              expect(retryAfter).toEqual(5);
-              expect(options).toMatchObject({
-                method: "GET",
-                url: "/route2",
-                request: { retryCount: 0 },
-              });
-              eventCount++;
-            },
-            onRateLimit: () => 1,
-          },
-        });
-
-        await octokit.request("GET /route1", {
-          request: {
-            responses: [{ status: 201, headers: {}, data: {} }],
-          },
-        });
-        try {
-          await octokit.request("GET /route2", {
-            request: {
-              responses: [
-                {
-                  status: 403,
-                  headers: {},
-                  data: {
-                    message: "You have exceeded a secondary rate limit",
-                  },
-                },
-              ],
-            },
-          });
-          throw new Error("Should not reach this point");
-        } catch (error: any) {
-          expect(error.status).toEqual(403);
-        }
-
-        expect(eventCount).toEqual(1);
-      });
     });
   });
 
@@ -360,10 +228,10 @@ describe("Events", function () {
       const octokit = new TestOctokit({
         throttle: {
           onRateLimit: () => {
-            throw new Error("Should not reach this point");
+            throw new Error("Error in onRateLimit handler");
           },
           onSecondaryRateLimit: () => {
-            throw new Error("Should not reach this point");
+            throw new Error("Error in onSecondaryRateLimit handler");
           },
         },
       });
@@ -397,7 +265,7 @@ describe("Events", function () {
         expect(error.status).toEqual(403);
         expect(octokit.log.warn).toHaveBeenCalledWith(
           "Error in throttling-plugin limit handler",
-          new Error("Should not reach this point")
+          new Error("Error in onRateLimit handler")
         );
       }
     });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -124,13 +124,13 @@ describe("Events", function () {
         expect(eventCount).toEqual(1);
       });
     });
-    describe("with 'onAbuseLimit'", function () {
+    describe("with 'onSecondaryRateLimit'", function () {
       it("Should detect SecondaryRate limit and broadcast event", async function () {
         let eventCount = 0;
 
         const octokit = new TestOctokit({
           throttle: {
-            onAbuseLimit: (retryAfter, options, octokitFromOptions) => {
+            onSecondaryRateLimit: (retryAfter, options, octokitFromOptions) => {
               expect(octokit).toBe(octokitFromOptions);
               expect(retryAfter).toEqual(60);
               expect(options).toMatchObject({

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -5,6 +5,8 @@ import { throttling } from "../src";
 import { AddressInfo } from "net";
 import { createServer } from "http";
 
+jest.setTimeout(20000);
+
 describe("Retry", function () {
   describe("REST", function () {
     it("Should retry 'secondary-limit' and succeed", async function () {
@@ -163,7 +165,14 @@ describe("Retry", function () {
         await octokit.request("GET /nope-nope-ok");
         await octokit.request("GET /nope-nope-ok");
       } finally {
-        server.close();
+        return new Promise((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              return reject(error);
+            }
+            resolve("ok");
+          });
+        });
       }
     });
 

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -11,7 +11,7 @@ describe("Retry", function () {
       let eventCount = 0;
       const octokit = new TestOctokit({
         throttle: {
-          minimumSecondaryRateRetryAfter: 0,
+          fallbackSecondaryRateRetryAfter: 0,
           retryAfterBaseValue: 50,
           onSecondaryRateLimit: (retryAfter, options) => {
             expect(options).toMatchObject({
@@ -57,7 +57,7 @@ describe("Retry", function () {
       let eventCount = 0;
       const octokit = new TestOctokit({
         throttle: {
-          minimumSecondaryRateRetryAfter: 0,
+          fallbackSecondaryRateRetryAfter: 0,
           retryAfterBaseValue: 50,
           onSecondaryRateLimit: (retryAfter, options) => {
             expect(options).toMatchObject({
@@ -147,7 +147,7 @@ describe("Retry", function () {
       const octokit = new ThrottledOctokit({
         baseUrl: `http://localhost:${port}`,
         throttle: {
-          minimumSecondaryRateRetryAfter: 0,
+          fallbackSecondaryRateRetryAfter: 0,
           retryAfterBaseValue: 50,
           onRateLimit: () => true,
           onSecondaryRateLimit: (retryAfter, options, octokit, retryCount) => {
@@ -405,7 +405,7 @@ describe("Retry", function () {
             return true;
           },
           onRateLimit: () => 1,
-          minimumSecondaryRateRetryAfter: 0,
+          fallbackSecondaryRateRetryAfter: 0,
           retryAfterBaseValue: 50,
         },
       });


### PR DESCRIPTION
I had a GitHub-internal discussion about this. We cannot give details on how secondary limit rating works as it is meant to avoid API abuse. But for now we came to an agreement that waiting 60s for retries is a good default implementation for handling.

Closes #454, closes #566. 