### PR TITLE
fix(types): don't require any properties if `enabled` is `false`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,11 @@ export type ThrottlingOptionsBase = {
   onRateLimit: LimitHandler;
 };
 
-export type ThrottlingOptions = ThrottlingOptionsBase &
-  (AbuseLimitHandler | SecondaryLimitHandler);
+export type ThrottlingOptions =
+  | (ThrottlingOptionsBase & (AbuseLimitHandler | SecondaryLimitHandler))
+  | (Partial<ThrottlingOptionsBase> & { enabled: false } & Partial<
+        AbuseLimitHandler | SecondaryLimitHandler
+      >);
 
 export type Groups = {
   global?: Bottleneck.Group;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,9 +40,9 @@ export type ThrottlingOptionsBase = {
 
 export type ThrottlingOptions =
   | (ThrottlingOptionsBase & (AbuseLimitHandler | SecondaryLimitHandler))
-  | (Partial<ThrottlingOptionsBase> & { enabled: false } & Partial<
-        AbuseLimitHandler | SecondaryLimitHandler
-      >);
+  | (Partial<
+      ThrottlingOptionsBase & (AbuseLimitHandler | SecondaryLimitHandler)
+    > & { enabled: false });
 
 export type Groups = {
   global?: Bottleneck.Group;


### PR DESCRIPTION
As per the README, it seems that when the `enabled` option is set to `false` no other property is needed, as the plugin is disabled.

Resolves https://github.com/octokit/octokit.js/pull/2448#issuecomment-1550519243