### PR TITLE
WIP avoid "Maximum call stack size exceeded" errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,9 +92,29 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
   const events = {};
   const emitter = new Bottleneck.Events(events);
   // @ts-expect-error
-  events.on("secondary-limit", state.onSecondaryRateLimit);
+  events.on("secondary-limit", async (...args) => {
+    try {
+      // @ts-expect-error
+      return await state.onSecondaryRateLimit(...args);
+    } catch (error) {
+      // avoid "Maximum call stack size exceeded" error
+      setTimeout(() => {
+        throw error;
+      });
+    }
+  });
   // @ts-expect-error
-  events.on("rate-limit", state.onRateLimit);
+  events.on("rate-limit", async (...args) => {
+    try {
+      // @ts-expect-error
+      return await state.onRateLimit(...args);
+    } catch (error) {
+      // avoid "Maximum call stack size exceeded" error
+      setTimeout(() => {
+        throw error;
+      });
+    }
+  });
   // @ts-expect-error
   events.on("error", (e) =>
     octokit.log.warn("Error in throttling-plugin limit handler", e)


### PR DESCRIPTION
This is somewhat odd. I ran into the maximum call stack error and worked around it locally using this fix. But we do test for when the rate handler methods throw, so I am not sure what is up yet. I will get back to it
