### PR TITLE
fix(retry): Retry requests after the x-ratelimit-reset time, not exactly at it.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,8 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
           ~~error.response.headers["x-ratelimit-reset"] * 1000,
         ).getTime();
         const retryAfter = Math.max(
-          // Add one so we retry _after_ the reset time.
+          // Add one second so we retry _after_ the reset time
+          // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
           Math.ceil((rateLimitReset - Date.now()) / 1000) + 1,
           0,
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,8 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
           ~~error.response.headers["x-ratelimit-reset"] * 1000,
         ).getTime();
         const retryAfter = Math.max(
-          Math.ceil((rateLimitReset - Date.now()) / 1000),
+          // Add one so we retry _after_ the reset time.
+          Math.ceil((rateLimitReset - Date.now()) / 1000) + 1,
           0,
         );
         const wantRetry = await emitter.trigger(

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -133,8 +133,8 @@ describe("Events", function () {
         throttle: {
           onRateLimit: (retryAfter, options, octokitFromOptions) => {
             expect(octokit).toBe(octokitFromOptions);
-            expect(retryAfter).toBeLessThan(32);
-            expect(retryAfter).toBeGreaterThan(28);
+            expect(retryAfter).toBeLessThan(33);
+            expect(retryAfter).toBeGreaterThan(29);
             expect(options).toMatchObject({
               method: "GET",
               url: "/route2",


### PR DESCRIPTION
Addresses #599, although it won't handle the case where the client and server actually have different times.