### PR TITLE
fix(graphql): GraphQL queries can exceed the rate limit even with x-ratelimit-remaining !== 0.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
       if (
         (error.response.headers != null &&
          error.response.headers["x-ratelimit-remaining"] === "0"
-        ) || (error.response.data?.errors ?? []).some((error) => error.type === "RATE_LIMITED")
+        ) || (error.response.data?.errors ?? []).some((error:any) => error.type === "RATE_LIMITED")
       ) {
         // The user has used all their allowed calls for the current time period (REST and GraphQL)
         // https://docs.github.com/en/rest/reference/rate-limit (REST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,9 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
         return { wantRetry, retryAfter };
       }
       if (
-        error.response.headers != null &&
-        error.response.headers["x-ratelimit-remaining"] === "0"
+        (error.response.headers != null &&
+         error.response.headers["x-ratelimit-remaining"] === "0"
+        ) || (error.response.data?.errors ?? []).some((error) => error.type === "RATE_LIMITED")
       ) {
         // The user has used all their allowed calls for the current time period (REST and GraphQL)
         // https://docs.github.com/en/rest/reference/rate-limit (REST)

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,8 +138,10 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
       }
       if (
         (error.response.headers != null &&
-         error.response.headers["x-ratelimit-remaining"] === "0"
-        ) || (error.response.data?.errors ?? []).some((error:any) => error.type === "RATE_LIMITED")
+          error.response.headers["x-ratelimit-remaining"] === "0") ||
+        (error.response.data?.errors ?? []).some(
+          (error: any) => error.type === "RATE_LIMITED",
+        )
       ) {
         // The user has used all their allowed calls for the current time period (REST and GraphQL)
         // https://docs.github.com/en/rest/reference/rate-limit (REST)

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -250,6 +250,8 @@ describe("Retry", function () {
             {
               status: 200,
               headers: {
+                // should retry based on response body, not header
+                // https://github.com/octokit/plugin-throttling.js/issues/632
                 "x-ratelimit-remaining": "1",
                 "x-ratelimit-reset": "123",
               },

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -250,7 +250,7 @@ describe("Retry", function () {
             {
               status: 200,
               headers: {
-                "x-ratelimit-remaining": "0",
+                "x-ratelimit-remaining": "1",
                 "x-ratelimit-reset": "123",
               },
               data: { errors: [{ type: "RATE_LIMITED" }] },
@@ -300,7 +300,7 @@ describe("Retry", function () {
             {
               status: 200,
               headers: {
-                "x-ratelimit-remaining": "0",
+                "x-ratelimit-remaining": "1",
                 "x-ratelimit-reset": "123",
               },
               data: { errors: [{ type: "RATE_LIMITED" }] },


### PR DESCRIPTION
This tries to fix #632, but I haven't tested it.