### PR TITLE
fix(types): improvements to internal types and `options` parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^12.2.0",
         "bottleneck": "^2.15.3"
       },
       "devDependencies": {
@@ -1853,9 +1853,9 @@
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.1.1.tgz",
-      "integrity": "sha512-qnJTldJ1NyGT5MTsCg/Zi+y2IFHZ1Jo5+njNCjJ9FcainV7LjuHgmB697kA0g4MjZeDAJsM3B45iqCVsCLVFZg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.2.0.tgz",
+      "integrity": "sha512-ZkdHqHJdifVndN7Pha10+qrgAjy3AcG//Vmjr/o5UFuTiYCcMhqDj39Yr9VM9zJ/42KO2xAYhV7cvLnLI9Kvwg==",
       "dependencies": {
         "@octokit/openapi-types": "^19.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
     "update-endpoints:code": "node scripts/update-endpoints/code",
-    "validate:ts": "tsc --noEmit --noImplicitAny --target es2020 --esModuleInterop --moduleResolution node test/typescript-validate.ts"
+    "validate:ts": "npm run build && tsc --noEmit --noImplicitAny --target es2020 --esModuleInterop --moduleResolution node test/typescript-validate.ts"
   },
   "repository": "github:octokit/plugin-throttling.js",
   "author": "Simon Grondin (http://github.com/SGrondin)",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Simon Grondin (http://github.com/SGrondin)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/types": "^12.0.0",
+    "@octokit/types": "^12.2.0",
     "bottleneck": "^2.15.3"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,11 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     }
   });
 
+  // @ts-expect-error
+  // The types for `before-after-hook` do not let us only pass through a Promise return value
+  // the types expect that the function can return either a Promise of the response, or diectly return the response.
+  // This is due to the fact that `@octokit/request` uses aysnc functions
+  // Also, since we add the custom `retryCount` property to the request argument, the types are not compatible.
   octokit.hook.wrap("request", wrapRequest.bind(null, state));
 
   return {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,6 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     octokit.log.warn("Error in throttling-plugin limit handler", e),
   );
 
-  // @ts-expect-error
   state.retryLimiter.on("failed", async function (error, info) {
     const [state, request, options] = info.args;
     const { pathname } = new URL(options.url, "http://github.test");

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,11 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
   );
 
   state.retryLimiter.on("failed", async function (error, info) {
-    const [state, request, options] = info.args as [State, OctokitResponse<any>, Required<EndpointDefaults>];
+    const [state, request, options] = info.args as [
+      State,
+      OctokitResponse<any>,
+      Required<EndpointDefaults>,
+    ];
     const { pathname } = new URL(options.url, "http://github.test");
     const shouldRetryGraphQL =
       pathname.startsWith("/graphql") && error.status !== 401;

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,11 +187,11 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     }
   });
 
-  // @ts-expect-error
   // The types for `before-after-hook` do not let us only pass through a Promise return value
   // the types expect that the function can return either a Promise of the response, or diectly return the response.
   // This is due to the fact that `@octokit/request` uses aysnc functions
   // Also, since we add the custom `retryCount` property to the request argument, the types are not compatible.
+  // @ts-expect-error
   octokit.hook.wrap("request", wrapRequest.bind(null, state));
 
   return {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // @ts-expect-error
 import BottleneckLight from "bottleneck/light";
+import type TBottleneck from "bottleneck";
 import { Octokit } from "@octokit/core";
 import type { OctokitOptions } from "@octokit/core/dist-types/types.d";
 import type { Groups, ThrottlingOptions } from "./types";
@@ -15,8 +16,16 @@ const triggersNotification = regex.test.bind(regex);
 
 const groups: Groups = {};
 
-// @ts-expect-error
-const createGroups = function (Bottleneck, common) {
+const createGroups = function (
+  Bottleneck: typeof TBottleneck,
+  common: {
+    connection:
+      | TBottleneck.RedisConnection
+      | TBottleneck.IORedisConnection
+      | undefined;
+    timeout: number;
+  },
+) {
   groups.global = new Bottleneck.Group({
     id: "octokit-global",
     maxConcurrent: 10,
@@ -45,7 +54,7 @@ const createGroups = function (Bottleneck, common) {
 export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
   const {
     enabled = true,
-    Bottleneck = BottleneckLight,
+    Bottleneck = BottleneckLight as typeof TBottleneck,
     id = "no-id",
     timeout = 1000 * 60 * 2, // Redis TTL: 2 minutes
     connection,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,13 @@ export type Groups = {
   search?: Bottleneck.Group;
   notifications?: Bottleneck.Group;
 };
+
+export type State = {
+  clustering: boolean;
+  triggersNotification: (pathname: string) => boolean;
+  fallbackSecondaryRateRetryAfter: number;
+  retryAfterBaseValue: number;
+  retryLimiter: Bottleneck;
+  id: string;
+} & Required<Groups> &
+  ThrottlingOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "@octokit/core";
+import type { EndpointDefaults } from "@octokit/types";
 import Bottleneck from "bottleneck";
 
 type LimitHandler = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import Bottleneck from "bottleneck";
 
 type LimitHandler = (
   retryAfter: number,
-  options: object,
+  options: Record<string, unknown>,
   octokit: Octokit,
   retryCount: number,
 ) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import Bottleneck from "bottleneck";
 
 type LimitHandler = (
   retryAfter: number,
-  options: Record<string, unknown>,
+  options: Required<EndpointDefaults>,
   octokit: Octokit,
   retryCount: number,
 ) => void;

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -5,7 +5,9 @@ const noop = () => Promise.resolve();
 
 export function wrapRequest(
   state: State,
-  request: (options: Required<EndpointDefaults>) => OctokitResponse<any, number> | Promise<OctokitResponse<any, number>>,
+  request: (
+    options: Required<EndpointDefaults>,
+  ) => OctokitResponse<any> | Promise<OctokitResponse<any>>,
   options: Required<EndpointDefaults>,
 ) {
   return state.retryLimiter.schedule(doRequest, state, request, options);
@@ -13,7 +15,9 @@ export function wrapRequest(
 
 async function doRequest(
   state: State,
-  request: (options: Required<EndpointDefaults>) => OctokitResponse<any> | Promise<OctokitResponse<any>>,
+  request: (
+    options: Required<EndpointDefaults>,
+  ) => OctokitResponse<any> | Promise<OctokitResponse<any>>,
   options: Required<EndpointDefaults>,
 ) {
   const isWrite = options.method !== "GET" && options.method !== "HEAD";
@@ -48,7 +52,13 @@ async function doRequest(
   }
 
   // @ts-expect-error
-  const req = state.global.key(state.id).schedule<OctokitResponse<any>, Required<EndpointDefaults>>(jobOptions, request, options);
+  const req = state.global
+    .key(state.id)
+    .schedule<OctokitResponse<any>, Required<EndpointDefaults>>(
+      jobOptions,
+      request,
+      options,
+    );
   if (isGraphQL) {
     const res = await req;
 

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -1,17 +1,27 @@
+import type { EndpointDefaults, OctokitResponse } from "@octokit/types";
+import type { State } from "./types";
+
 const noop = () => Promise.resolve();
 
-// @ts-expect-error
-export function wrapRequest(state, request, options) {
+export function wrapRequest(
+  state: State,
+  request: (options: Required<EndpointDefaults>) => OctokitResponse<any, number> | Promise<OctokitResponse<any, number>>,
+  options: Required<EndpointDefaults>,
+) {
   return state.retryLimiter.schedule(doRequest, state, request, options);
 }
 
-// @ts-expect-error
-async function doRequest(state, request, options) {
+async function doRequest(
+  state: State,
+  request: (options: Required<EndpointDefaults>) => OctokitResponse<any> | Promise<OctokitResponse<any>>,
+  options: Required<EndpointDefaults>,
+) {
   const isWrite = options.method !== "GET" && options.method !== "HEAD";
   const { pathname } = new URL(options.url, "http://github.test");
   const isSearch = options.method === "GET" && pathname.startsWith("/search/");
   const isGraphQL = pathname.startsWith("/graphql");
 
+  // @ts-expect-errors
   const retryCount = ~~request.retryCount;
   const jobOptions = retryCount > 0 ? { priority: 0, weight: 0 } : {};
   if (state.clustering) {
@@ -37,7 +47,8 @@ async function doRequest(state, request, options) {
     await state.search.key(state.id).schedule(jobOptions, noop);
   }
 
-  const req = state.global.key(state.id).schedule(jobOptions, request, options);
+  // @ts-expect-error
+  const req = state.global.key(state.id).schedule<OctokitResponse<any>, Required<EndpointDefaults>>(jobOptions, request, options);
   if (isGraphQL) {
     const res = await req;
 

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -51,11 +51,11 @@ async function doRequest(
     await state.search.key(state.id).schedule(jobOptions, noop);
   }
 
-  // @ts-expect-error
   const req = state.global
     .key(state.id)
     .schedule<OctokitResponse<any>, Required<EndpointDefaults>>(
       jobOptions,
+      // @ts-expect-error
       request,
       options,
     );

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -10,7 +10,9 @@ describe("Exports", function () {
     };
 
     options.enabled = false;
+    // @ts-expect-error
     options.onRateLimit(10, {}, {} as Octokit, 0);
+    // @ts-expect-error
     options.onSecondaryRateLimit(10, {}, {} as Octokit, 0);
   });
 });

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "@octokit/core";
-import { throttling } from "../src/index";
+import { throttling } from "../pkg";
 // ************************************************************
 // THIS CODE IS NOT EXECUTED. IT IS FOR TYPECHECKING ONLY
 // ************************************************************


### PR DESCRIPTION
Fixes #641

This should unblock users, as using `object` doesn't allow users to access options properties in TypeScript.

The types were inferred from the call to `octokit.hook.wrap()`, and also confirmed from the types from`@octokit/core`

https://github.com/octokit/core.js/blob/1c64ce28a2352c88091732985502b257cb242c02/src/types.ts#L55-L59