### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@
 import BottleneckLight from "bottleneck/light";
 import type TBottleneck from "bottleneck";
 import { Octokit } from "@octokit/core";
-import type { OctokitOptions } from "@octokit/core/dist-types/types.d";
-import type { Groups, State, ThrottlingOptions } from "./types";
-import { VERSION } from "./version";
+import type { OctokitOptions } from "@octokit/core/dist-types/types.d.js";
+import type { Groups, State, ThrottlingOptions } from "./types.js";
+import { VERSION } from "./version.js";
 
-import { wrapRequest } from "./wrap-request";
-import triggersNotificationPaths from "./generated/triggers-notification-paths";
-import { routeMatcher } from "./route-matcher";
+import { wrapRequest } from "./wrap-request.js";
+import triggersNotificationPaths from "./generated/triggers-notification-paths.js";
+import { routeMatcher } from "./route-matcher.js";
 import type { EndpointDefaults, OctokitResponse } from "@octokit/types";
 
 // Workaround to allow tests to directly access the triggersNotification function.

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -1,5 +1,5 @@
 import type { EndpointDefaults, OctokitResponse } from "@octokit/types";
-import type { State } from "./types";
+import type { State } from "./types.js";
 
 const noop = () => Promise.resolve();
 

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,4 +1,4 @@
-import { TestOctokit } from "./octokit";
+import { TestOctokit } from "./octokit.ts";
 
 describe("Events", function () {
   it("Should support non-limit 403s", async function () {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,4 +1,4 @@
-import type { ThrottlingOptions } from "../src";
+import type { ThrottlingOptions } from "../src/index.ts";
 import type { Octokit } from "@octokit/core";
 
 describe("Exports", function () {

--- a/test/octokit.ts
+++ b/test/octokit.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/core";
 import { RequestError } from "@octokit/request-error";
-import { throttling } from "../src";
+import { throttling } from "../src/index.ts";
 
 function testPlugin(octokit: Octokit) {
   const t0 = Date.now();

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,6 +1,6 @@
 import Bottleneck from "bottleneck";
-import { TestOctokit } from "./octokit";
-import { throttling } from "../src";
+import { TestOctokit } from "./octokit.ts";
+import { throttling } from "../src/index.ts";
 
 describe("General", function () {
   it("Should be possible to disable the plugin", async function () {

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -2,8 +2,8 @@ import Bottleneck from "bottleneck";
 import { TestOctokit } from "./octokit";
 import { Octokit } from "@octokit/core";
 import { throttling } from "../src";
-import { AddressInfo } from "net";
-import { createServer } from "http";
+import { AddressInfo } from "node:net";
+import { createServer } from "node:http";
 
 jest.setTimeout(20000);
 

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,7 +1,7 @@
 import Bottleneck from "bottleneck";
-import { TestOctokit } from "./octokit";
+import { TestOctokit } from "./octokit.ts";
 import { Octokit } from "@octokit/core";
-import { throttling } from "../src";
+import { throttling } from "../src/index.ts";
 import { AddressInfo } from "node:net";
 import { createServer } from "node:http";
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { throttling } from "../src";
+import { throttling } from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.