### PR TITLE
fix(pkg): add `main` field

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -61,6 +61,8 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
+        main: "dist-bundle/index.js",
+        types: "dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -61,6 +61,9 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
+        // Tooling currently are having issues with the "exports" field, ex: TypeScript, eslint
+        // We add a `main` and `types` field to the package.json for the time being
+        // See https://github.com/octokit/core.js/pulls/662
         main: "dist-bundle/index.js",
         types: "dist-types/index.d.ts",
         exports: {


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.
See https://github.com/octokit/core.js/pull/662