### PR TITLE
Added "default" export in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ import { throttling } from "@octokit/plugin-throttling";
 </tbody>
 </table>
 
+> [!IMPORTANT]
+> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json` by setting `"moduleResolution": "node16", "module": "node16"`.
+>
+> See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).<br>
+> See this [helpful guide on transitioning to ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) from [@sindresorhus](https://github.com/sindresorhus)
+
 The code below creates a "Hello, world!" issue on every repository in a given organization. Without the throttling plugin it would send many requests in parallel and would hit rate limits very quickly. But the `@octokit/plugin-throttling` slows down your requests according to the official guidelines, so you don't get blocked before your quota is exhausted.
 
 The `throttle.onSecondaryRateLimit` and `throttle.onRateLimit` options are required. Return `true` to automatically retry the request after `retryAfter` seconds.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -61,15 +61,13 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        // Tooling currently are having issues with the "exports" field, ex: TypeScript, eslint
-        // We add a `main` and `types` field to the package.json for the time being
-        // See https://github.com/octokit/core.js/pulls/662
-        main: "dist-bundle/index.js",
         types: "dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-bundle/index.js",
+            // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint, ncc
+            // See https://github.com/octokit/core.js/issues/667#issuecomment-2037592361
             default: "./dist-bundle/index.js",
           },
         },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -70,6 +70,7 @@ async function main() {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-bundle/index.js",
+            default: "./dist-bundle/index.js",
           },
         },
         sideEffects: false,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -68,6 +68,7 @@ async function main() {
             import: "./dist-bundle/index.js",
             // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint, ncc
             // See https://github.com/octokit/core.js/issues/667#issuecomment-2037592361
+            // See https://github.com/octokit/plugin-throttling.js/issues/694
             default: "./dist-bundle/index.js",
           },
         },


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #694

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No "default" defined in package.json -> exports['.']

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* "default" field appended to package.json -> exports['.']

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->


Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

### Related PRs
https://github.com/octokit/plugin-retry.js/pull/542
https://github.com/octokit/plugin-paginate-graphql.js/pull/195