### PR TITLE
docs(comment): outdated information about the default secondary retry after

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,7 +136,7 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
         // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
 
         // The Retry-After header can sometimes be blank when hitting a secondary rate limit,
-        // but is always present after 2-3s, so make sure to set `retryAfter` to at least 5s by default.
+        // but is always present after 2-3s, so make sure to set `retryAfter` to at least 60s by default.
         const retryAfter =
           Number(error.response.headers["retry-after"]) ||
           state.fallbackSecondaryRateRetryAfter;


### PR DESCRIPTION
This was originally 5s:
https://github.com/octokit/plugin-throttling.js/blob/64c537ec3b292afeee63cf1439f95a5894c7b786/src/index.ts#L71
but it was changed in 
https://github.com/octokit/plugin-throttling.js/pull/594