### PR TITLE
fix: only import Octokit as type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 // @ts-expect-error No types for "bottleneck/light"
 import BottleneckLight from "bottleneck/light.js";
 import type TBottleneck from "bottleneck";
-import { Octokit } from "@octokit/core";
-import type { OctokitOptions } from "@octokit/core";
+import type { Octokit, OctokitOptions } from "@octokit/core";
 import type { Groups, State, ThrottlingOptions } from "./types.js";
 import { VERSION } from "./version.js";
 


### PR DESCRIPTION
we can import Octokit only as type. 
Avoids basically a useless require. 

first merge #720 , then i remove the draft, than it should result in a release.