### PR TITLE
Remove outdated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Node
 
 Install with `npm install @octokit/core @octokit/plugin-throttling`. Optionally replace `@octokit/core` with a core-compatible module.
 
-**Note**: If you use it with `@octokit/rest` v16, install `@octokit/core` as a devDependency. This is only temporary and will no longer be necessary with `@octokit/rest` v17.
-
 ```js
 import { Octokit } from "@octokit/core";
 import { throttling } from "@octokit/plugin-throttling";


### PR DESCRIPTION
v17 shipped 4+ years ago, so I think it's safe to remove this warning now.

I realize some folks will still be using v16 and below, but it's a reasonably safe assumption those will be legacy apps that are relatively stable and not under active development.