### PR TITLE
fix: treat GraphQL `RATE_LIMIT` as equivalent to `RATE_LIMITED`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,13 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
         (error.response.headers != null &&
           error.response.headers["x-ratelimit-remaining"] === "0") ||
         (error.response.data?.errors ?? []).some(
-          (error: any) => error.type === "RATE_LIMITED",
+          // GitHub's GraphQL API has been observed to return `RATE_LIMIT`
+          // (the value of the corresponding GraphQL `code` field) instead of
+          // the documented `RATE_LIMITED` enum value on the `type` field, so
+          // both must be treated as the same condition.
+          // https://github.com/octokit/plugin-throttling.js/issues/824
+          (error: any) =>
+            error.type === "RATE_LIMITED" || error.type === "RATE_LIMIT",
         )
       ) {
         // The user has used all their allowed calls for the current time period (REST and GraphQL)

--- a/src/wrap-request.ts
+++ b/src/wrap-request.ts
@@ -63,7 +63,13 @@ async function doRequest(
 
     if (
       res.data.errors != null &&
-      res.data.errors.some((error: any) => error.type === "RATE_LIMITED")
+      res.data.errors.some(
+        // GitHub's GraphQL API has been observed to return `RATE_LIMIT`
+        // instead of the documented `RATE_LIMITED` enum value; accept both.
+        // https://github.com/octokit/plugin-throttling.js/issues/824
+        (error: any) =>
+          error.type === "RATE_LIMITED" || error.type === "RATE_LIMIT",
+      )
     ) {
       const error = Object.assign(new Error("GraphQL Rate Limit Exceeded"), {
         response: res,

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -332,6 +332,56 @@ describe("Retry", { timeout: 20000 }, function () {
       expect(ms).toBeGreaterThan(30);
     });
 
+    // GitHub's GraphQL API has been observed to return `RATE_LIMIT`
+    // (the GraphQL `code` value) rather than the documented `RATE_LIMITED`
+    // enum value on the `type` field. The throttling plugin must treat both
+    // as the same condition. https://github.com/octokit/plugin-throttling.js/issues/824
+    it("Should retry when GraphQL returns 'RATE_LIMIT' instead of 'RATE_LIMITED'", async function () {
+      let eventCount = 0;
+      const octokit = new TestOctokit({
+        throttle: {
+          write: new Bottleneck.Group({ minTime: 50 }),
+          onRateLimit: (retryAfter, options) => {
+            expect(options).toMatchObject({
+              method: "POST",
+              url: "/graphql",
+              request: { retryCount: eventCount },
+            });
+            expect(retryAfter).toEqual(0);
+            eventCount++;
+            return true;
+          },
+          onSecondaryRateLimit: () => 1,
+        },
+      });
+
+      const res = await octokit.request("POST /graphql", {
+        request: {
+          responses: [
+            {
+              status: 200,
+              headers: {
+                "x-ratelimit-remaining": "1",
+                "x-ratelimit-reset": "123",
+              },
+              data: { errors: [{ type: "RATE_LIMIT" }] },
+            },
+            { status: 200, headers: {}, data: { message: "Yay!" } },
+          ],
+        },
+      });
+
+      expect(res.status).toEqual(200);
+      expect(res.data).toMatchObject({ message: "Yay!" });
+      expect(eventCount).toEqual(1);
+      expect(octokit.__requestLog).toStrictEqual([
+        "START POST /graphql",
+        "END POST /graphql",
+        "START POST /graphql",
+        "END POST /graphql",
+      ]);
+    });
+
     it("Should ignore other error types", async function () {
       let eventCount = 0;
       const octokit = new TestOctokit({


### PR DESCRIPTION
## Why

Closes #824.

GitHub's GraphQL API has been observed to return `type: "RATE_LIMIT"` (the GraphQL `code` value) instead of the documented `RATE_LIMITED` enum value when a rate limit is hit. The issue reporter attached two real-world response bodies (migration query and repository list query) both showing `"type": "RATE_LIMIT"` in the `errors` array.

Today the plugin only matches on `RATE_LIMITED`, so the retry path is skipped for the `RATE_LIMIT` variant — the caller sees a one-shot failure instead of the standard back-off retry.

## What

- `src/index.ts:162`: accept `error.type === "RATE_LIMITED" || error.type === "RATE_LIMIT"` in the rate-limit detection branch.
- `src/wrap-request.ts:66`: same check on the GraphQL response inspection path.
- Both call sites now carry a short comment explaining the dual-string behaviour and link back to the issue.

## Tests

New regression test `Should retry when GraphQL returns 'RATE_LIMIT' instead of 'RATE_LIMITED'` in `test/retry.test.ts` — mirrors the existing "Should retry 'rate-limit' and succeed" test but with `type: "RATE_LIMIT"` in the error payload. Verifies the retry fires and the second response is the one returned.

All 31 tests pass locally; lint clean.