### PR TITLE
fix: defer Bottleneck instantiation until first request (CF Workers compat)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,22 +71,16 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     common.connection = connection;
   }
 
-  if (groups.global == null) {
-    createGroups(Bottleneck, common);
-  }
-
   const state: State = Object.assign(
     {
       clustering: connection != null,
       triggersNotification,
       fallbackSecondaryRateRetryAfter: 60,
       retryAfterBaseValue: 1000,
-      retryLimiter: new Bottleneck(),
       id,
-      ...(groups as Required<Groups>),
     },
     octokitOptions.throttle,
-  );
+  ) as State;
 
   if (
     typeof state.onSecondaryRateLimit !== "function" ||
@@ -105,100 +99,133 @@ export function throttling(octokit: Octokit, octokitOptions: OctokitOptions) {
     `);
   }
 
-  const events = {};
-  const emitter = new Bottleneck.Events(events);
-  // @ts-expect-error
-  events.on("secondary-limit", state.onSecondaryRateLimit);
-  // @ts-expect-error
-  events.on("rate-limit", state.onRateLimit);
-  // @ts-expect-error
-  events.on("error", (e) =>
-    octokit.log.warn("Error in throttling-plugin limit handler", e),
-  );
-
-  state.retryLimiter.on("failed", async function (error, info) {
-    const [state, request, options] = info.args as [
-      State,
-      OctokitResponse<any>,
-      Required<EndpointDefaults>,
-    ];
-    const { pathname } = new URL(options.url, "http://github.test");
-    const shouldRetryGraphQL =
-      pathname.startsWith("/graphql") && error.status !== 401;
-
-    if (!(shouldRetryGraphQL || error.status === 403 || error.status === 429)) {
+  // Bottleneck.Group's constructor schedules a `setInterval` for auto-cleanup,
+  // and `new Bottleneck()` / `new Bottleneck.Events()` set up timers too. All
+  // three are disallowed in Cloudflare Workers' global scope (and any other
+  // environment that bans async I/O at import time). Defer every Bottleneck
+  // instantiation to the first request, where execution is guaranteed to be
+  // inside a handler.
+  // https://github.com/octokit/plugin-throttling.js/issues/794
+  let initialized = false;
+  const initializeBottleneck = () => {
+    if (initialized) {
       return;
     }
+    initialized = true;
 
-    const retryCount = ~~request.retryCount;
-    request.retryCount = retryCount;
-
-    // backward compatibility
-    options.request.retryCount = retryCount;
-
-    const { wantRetry, retryAfter = 0 } = await (async function () {
-      if (/\bsecondary rate\b/i.test(error.message)) {
-        // The user has hit the secondary rate limit. (REST and GraphQL)
-        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
-
-        // The Retry-After header can sometimes be blank when hitting a secondary rate limit,
-        // but is always present after 2-3s, so make sure to set `retryAfter` to at least 60s by default.
-        const retryAfter =
-          Number(error.response.headers["retry-after"]) ||
-          state.fallbackSecondaryRateRetryAfter;
-        const wantRetry = await emitter.trigger(
-          "secondary-limit",
-          retryAfter,
-          options,
-          octokit,
-          retryCount,
-        );
-        return { wantRetry, retryAfter };
-      }
-      if (
-        (error.response.headers != null &&
-          error.response.headers["x-ratelimit-remaining"] === "0") ||
-        (error.response.data?.errors ?? []).some(
-          (error: any) => error.type === "RATE_LIMITED",
-        )
-      ) {
-        // The user has used all their allowed calls for the current time period (REST and GraphQL)
-        // https://docs.github.com/en/rest/reference/rate-limit (REST)
-        // https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit (GraphQL)
-
-        const rateLimitReset = new Date(
-          ~~error.response.headers["x-ratelimit-reset"] * 1000,
-        ).getTime();
-        const retryAfter = Math.max(
-          // Add one second so we retry _after_ the reset time
-          // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
-          Math.ceil((rateLimitReset - Date.now()) / 1000) + 1,
-          0,
-        );
-        const wantRetry = await emitter.trigger(
-          "rate-limit",
-          retryAfter,
-          options,
-          octokit,
-          retryCount,
-        );
-        return { wantRetry, retryAfter };
-      }
-      return {};
-    })();
-
-    if (wantRetry) {
-      request.retryCount++;
-      return retryAfter * state.retryAfterBaseValue;
+    if (groups.global == null) {
+      createGroups(Bottleneck, common);
     }
-  });
+    // Defaults from `groups`, but only where the caller didn't already
+    // supply a custom Group via `octokitOptions.throttle` (e.g.
+    // `throttle: { write: new Bottleneck.Group({ minTime: 50 }) }`).
+    state.global = state.global ?? groups.global!;
+    state.auth = state.auth ?? groups.auth!;
+    state.search = state.search ?? groups.search!;
+    state.write = state.write ?? groups.write!;
+    state.notifications = state.notifications ?? groups.notifications!;
+    state.retryLimiter = state.retryLimiter ?? new Bottleneck();
+
+    const events = {};
+    const emitter = new Bottleneck.Events(events);
+    // @ts-expect-error
+    events.on("secondary-limit", state.onSecondaryRateLimit);
+    // @ts-expect-error
+    events.on("rate-limit", state.onRateLimit);
+    // @ts-expect-error
+    events.on("error", (e) =>
+      octokit.log.warn("Error in throttling-plugin limit handler", e),
+    );
+
+    state.retryLimiter.on("failed", async function (error, info) {
+      const [state, request, options] = info.args as [
+        State,
+        OctokitResponse<any>,
+        Required<EndpointDefaults>,
+      ];
+      const { pathname } = new URL(options.url, "http://github.test");
+      const shouldRetryGraphQL =
+        pathname.startsWith("/graphql") && error.status !== 401;
+
+      if (
+        !(shouldRetryGraphQL || error.status === 403 || error.status === 429)
+      ) {
+        return;
+      }
+
+      const retryCount = ~~request.retryCount;
+      request.retryCount = retryCount;
+
+      // backward compatibility
+      options.request.retryCount = retryCount;
+
+      const { wantRetry, retryAfter = 0 } = await (async function () {
+        if (/\bsecondary rate\b/i.test(error.message)) {
+          // The user has hit the secondary rate limit. (REST and GraphQL)
+          // https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
+
+          // The Retry-After header can sometimes be blank when hitting a secondary rate limit,
+          // but is always present after 2-3s, so make sure to set `retryAfter` to at least 60s by default.
+          const retryAfter =
+            Number(error.response.headers["retry-after"]) ||
+            state.fallbackSecondaryRateRetryAfter;
+          const wantRetry = await emitter.trigger(
+            "secondary-limit",
+            retryAfter,
+            options,
+            octokit,
+            retryCount,
+          );
+          return { wantRetry, retryAfter };
+        }
+        if (
+          (error.response.headers != null &&
+            error.response.headers["x-ratelimit-remaining"] === "0") ||
+          (error.response.data?.errors ?? []).some(
+            (error: any) => error.type === "RATE_LIMITED",
+          )
+        ) {
+          // The user has used all their allowed calls for the current time period (REST and GraphQL)
+          // https://docs.github.com/en/rest/reference/rate-limit (REST)
+          // https://docs.github.com/en/graphql/overview/resource-limitations#rate-limit (GraphQL)
+
+          const rateLimitReset = new Date(
+            ~~error.response.headers["x-ratelimit-reset"] * 1000,
+          ).getTime();
+          const retryAfter = Math.max(
+            // Add one second so we retry _after_ the reset time
+            // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+            Math.ceil((rateLimitReset - Date.now()) / 1000) + 1,
+            0,
+          );
+          const wantRetry = await emitter.trigger(
+            "rate-limit",
+            retryAfter,
+            options,
+            octokit,
+            retryCount,
+          );
+          return { wantRetry, retryAfter };
+        }
+        return {};
+      })();
+
+      if (wantRetry) {
+        request.retryCount++;
+        return retryAfter * state.retryAfterBaseValue;
+      }
+    });
+  };
 
   // The types for `before-after-hook` do not let us only pass through a Promise return value
   // the types expect that the function can return either a Promise of the response, or directly return the response.
   // This is due to the fact that `@octokit/request` uses aysnc functions
   // Also, since we add the custom `retryCount` property to the request argument, the types are not compatible.
-  // @ts-ignore We use the ignore instead of expect-error because TypeScript cannot make up it's mind if there is an error or not.
-  octokit.hook.wrap("request", wrapRequest.bind(null, state));
+  octokit.hook.wrap("request", (request, options) => {
+    initializeBottleneck();
+    // @ts-ignore We use the ignore instead of expect-error because TypeScript cannot make up it's mind if there is an error or not.
+    return wrapRequest(state, request, options);
+  });
 
   return {};
 }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -83,6 +83,42 @@ describe("General", function () {
         }),
     ).not.toThrow();
   });
+
+  // Bottleneck.Group / `new Bottleneck()` schedule timers in their
+  // constructors. Cloudflare Workers (and other restricted runtimes) reject
+  // `setTimeout` / `setInterval` at module-scope evaluation, so the plugin
+  // must defer all Bottleneck instantiation to the first request rather
+  // than running it eagerly inside `new Octokit()`.
+  // https://github.com/octokit/plugin-throttling.js/issues/794
+  it("Should not create any Bottleneck instances synchronously during `new Octokit()`", function () {
+    let constructed = 0;
+    class TrackedBottleneck extends Bottleneck {
+      constructor(...args: ConstructorParameters<typeof Bottleneck>) {
+        super(...args);
+        constructed++;
+      }
+    }
+    // @ts-expect-error mirror the live API surface for the test double
+    TrackedBottleneck.Group = class extends Bottleneck.Group {
+      constructor(...args: ConstructorParameters<typeof Bottleneck.Group>) {
+        super(...args);
+        constructed++;
+      }
+    };
+    // @ts-expect-error events surface
+    TrackedBottleneck.Events = Bottleneck.Events;
+
+    new TestOctokit({
+      throttle: {
+        // @ts-expect-error Use the tracking double instead of the default
+        Bottleneck: TrackedBottleneck,
+        onSecondaryRateLimit: () => 1,
+        onRateLimit: () => 1,
+      },
+    });
+
+    expect(constructed).toBe(0);
+  });
 });
 
 describe("GitHub API best practices", function () {


### PR DESCRIPTION
## Why

Closes #794.

`Bottleneck.Group` schedules a `setInterval` for auto-cleanup in its constructor, `new Bottleneck()` schedules timers, and `new Bottleneck.Events()` registers handlers. Cloudflare Workers (and any other runtime that bans async I/O at module-scope evaluation) reject all three when `new Octokit({ ... })` is constructed at the top level of a Worker — the typical pattern when bindings are imported globally:

```ts
import { env } from "cloudflare:workers";
import { Octokit } from "octokit";

export const github = new Octokit({ auth: env.GITHUB_TOKEN }); // throws
```

The user-visible error is `Disallowed operation called within global scope. Asynchronous I/O (ex: fetch() or connect()), setting a timeout, and generating random values are not allowed within global scope.` with a stack pointing at `_startAutoCleanup` inside Bottleneck's Group constructor.

The reporter's workaround today is to strip the throttling plugin entirely (`Octokit.plugins = Octokit.plugins.filter(...)`), which loses retry/rate-limit handling for the entire Worker.

## What

Restructured `throttling()` so it does no Bottleneck work itself. All Bottleneck instantiations — the five default `Group`s, the internal `retryLimiter`, the `Bottleneck.Events` emitter, and the `failed` handler attached to `retryLimiter` — are lifted into an `initializeBottleneck()` thunk that runs from the request hook on the very first call.

A few things to call out for review:

- **Validation is preserved.** `onRateLimit` / `onSecondaryRateLimit` presence is still checked synchronously inside `throttling()`, so misuse is reported at `new Octokit()` time exactly as before.
- **Custom Groups still win.** The init function uses `state.global ?? groups.global!` (and friends), so the existing test patterns where the caller passes their own `throttle.write: new Bottleneck.Group({ minTime: 50 })` continue to take precedence over the module-level defaults.
- **No behaviour change on the request path.** `wrapRequest` is unchanged; the only difference is that the first request runs the init thunk before delegating.

## Tests

- All existing tests pass (31 passed, 1 skipped, same as `main`).
- New regression test in `test/plugin.test.ts` swaps in a tracked `Bottleneck` double and asserts **zero** constructor calls happen during `new TestOctokit({...})`. Without the deferred init this fails immediately.

`npx tsc --noEmit`, `npm test`, `npx prettier --check src/index.ts` — all clean.